### PR TITLE
Update Reveal-Sc2Opponent.ps1 with opponents.txt fix

### DIFF
--- a/Reveal-Sc2Opponent.ps1
+++ b/Reveal-Sc2Opponent.ps1
@@ -16,10 +16,12 @@
 )
 
 Add-Type -AssemblyName Microsoft.PowerShell.Commands.Utility
-if($Test) { Write-Warning "Test mode" }
-if(-not [string]::IsNullOrEmpty($FilePath)) {
+if(Test-Path -Path $FilePath) {
     Clear-Content -Path $FilePath
     Write-Verbose "Cleared $FilePath"
+} else {
+    New-Item -Path $FilePath -ItemType File
+    Write-Verbose "Created and cleared $FilePath"
 }
 
 $Sc2PulseApiRoot = "https://sc2pulse.nephest.com/sc2/api"


### PR DESCRIPTION
check if opponents.txt exists before attempting to clear its content. If the file does not exist, we can either skip the clearing or create the file.